### PR TITLE
Disable timeout when waiting for transaction lock to become available

### DIFF
--- a/src/libwfp/filterengine.cpp
+++ b/src/libwfp/filterengine.cpp
@@ -11,21 +11,34 @@ namespace wfp
 //static
 std::unique_ptr<FilterEngine> FilterEngine::DynamicSession()
 {
-	return std::make_unique<FilterEngine>(true, ctor_tag{});
+	// A timeout of 0 ms is interpreted by WFP to mean "system default timeout".
+	return std::make_unique<FilterEngine>(true, 0, ctor_tag{});
 }
 
 //static
 std::unique_ptr<FilterEngine> FilterEngine::StandardSession()
 {
-	return std::make_unique<FilterEngine>(false, ctor_tag{});
+	// A timeout of 0 ms is interpreted by WFP to mean "system default timeout".
+	return std::make_unique<FilterEngine>(false, 0, ctor_tag{});
 }
 
-FilterEngine::FilterEngine(bool dynamic, ctor_tag)
+//static
+std::unique_ptr<FilterEngine> FilterEngine::DynamicSession(uint32_t timeout)
+{
+	return std::make_unique<FilterEngine>(true, timeout, ctor_tag{});
+}
+
+//static
+std::unique_ptr<FilterEngine> FilterEngine::StandardSession(uint32_t timeout)
+{
+	return std::make_unique<FilterEngine>(false, timeout, ctor_tag{});
+}
+
+FilterEngine::FilterEngine(bool dynamic, uint32_t timeout, ctor_tag)
 {
 	FWPM_SESSION0 sessionInfo = { 0 };
 
-	// Wait indefinitely for transaction lock to become available.
-	sessionInfo.txnWaitTimeoutInMSec = INFINITE;
+	sessionInfo.txnWaitTimeoutInMSec = timeout;
 
 	if (dynamic)
 	{

--- a/src/libwfp/filterengine.h
+++ b/src/libwfp/filterengine.h
@@ -14,11 +14,19 @@ class FilterEngine
 
 public:
 
+	// Create a session using a default timeout when waiting for the transaction lock.
+	// The system default timeout on Windows 10 is 100 minutes.
 	static std::unique_ptr<FilterEngine> DynamicSession();
 	static std::unique_ptr<FilterEngine> StandardSession();
 
+	// Create a session using a specific timeout when waiting for the transaction lock.
+	// Specifying a timeout of INFINITE will cause an indefinite wait.
+	// Zero is a reserved value in this context and means "system default timeout".
+	static std::unique_ptr<FilterEngine> DynamicSession(uint32_t timeout);
+	static std::unique_ptr<FilterEngine> StandardSession(uint32_t timeout);
+
 	// Public but non-invokable
-	FilterEngine(bool dynamic, ctor_tag);
+	FilterEngine(bool dynamic, uint32_t timeout, ctor_tag);
 
 	~FilterEngine();
 


### PR DESCRIPTION
Most API functions in WFP will create an implicit transaction if the current thread is not already in a transaction. That means pretty much all API functions can fail because they aren't able to set up a transaction in a timely manner. This change disables the timeout and causes the thread to wait indefinitely to acquire the transaction lock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wfp/3)
<!-- Reviewable:end -->
