### PR TITLE
Update loopback condition to match on traffic category by default

### DIFF
--- a/src/libwfp/conditions/conditionloopback.cpp
+++ b/src/libwfp/conditions/conditionloopback.cpp
@@ -9,24 +9,89 @@ using ConditionAssembler = ::wfp::internal::ConditionAssembler;
 
 namespace wfp::conditions {
 
-ConditionLoopback::ConditionLoopback(const IStrictComparison &comparison)
-	: m_comparison(comparison)
+namespace
 {
-	m_assembled = ConditionAssembler::Uint32(identifier(), m_comparison.op(), UINT32(IF_TYPE_SOFTWARE_LOOPBACK));
+
+FWP_MATCH_TYPE GetFlagsMatchType(const ComparisonSpecification &comp)
+{
+	switch (comp.op())
+	{
+		case FWP_MATCH_EQUAL: return FWP_MATCH_FLAGS_ALL_SET;
+		case FWP_MATCH_NOT_EQUAL: return FWP_MATCH_FLAGS_NONE_SET;
+		default:
+		{
+			throw std::logic_error("Missing case handler in switch clause");
+		}
+	}
+}
+
+} // anonymous namespace
+
+ConditionLoopback::ConditionLoopback(Type type, const IStrictComparison &comparison)
+	: m_type(type)
+	, m_comparison(comparison)
+{
+	switch (m_type)
+	{
+		case Type::LoopbackInterface:
+		{
+			m_assembled = ConditionAssembler::Uint32(identifier(),
+				m_comparison.op(), UINT32(IF_TYPE_SOFTWARE_LOOPBACK));
+
+			break;
+		}
+		case Type::LoopbackTraffic:
+		{
+			m_assembled = ConditionAssembler::Uint32(identifier(),
+				GetFlagsMatchType(m_comparison), UINT32(FWP_CONDITION_FLAG_IS_LOOPBACK));
+
+			break;
+		}
+		default:
+		{
+			throw std::logic_error("Missing case handler in switch clause");
+		}
+	}
 }
 
 std::wstring ConditionLoopback::toString() const
 {
 	std::wstringstream ss;
 
-	ss << L"interface " << m_comparison.toString() << L" loopback";
+	switch (m_type)
+	{
+		case Type::LoopbackInterface:
+		{
+			ss << L"interface ";
+			break;
+		}
+		case Type::LoopbackTraffic:
+		{
+			ss << L"traffic category ";
+			break;
+		}
+		default:
+		{
+			throw std::logic_error("Missing case handler in switch clause");
+		}
+	}
+
+	ss << m_comparison.toString() << L" loopback";
 
 	return ss.str();
 }
 
 const GUID &ConditionLoopback::identifier() const
 {
-	return FWPM_CONDITION_INTERFACE_TYPE;
+	switch (m_type)
+	{
+		case Type::LoopbackInterface: return FWPM_CONDITION_INTERFACE_TYPE;
+		case Type::LoopbackTraffic: return FWPM_CONDITION_FLAGS;
+		default:
+		{
+			throw std::logic_error("Missing case handler in switch clause");
+		}
+	}
 }
 
 const FWPM_FILTER_CONDITION0 &ConditionLoopback::condition() const

--- a/src/libwfp/conditions/conditionloopback.h
+++ b/src/libwfp/conditions/conditionloopback.h
@@ -10,7 +10,13 @@ class ConditionLoopback : public IFilterCondition
 {
 public:
 
-	ConditionLoopback(const IStrictComparison &comparison = CompareEq());
+	enum class Type
+	{
+		LoopbackInterface,
+		LoopbackTraffic
+	};
+
+	ConditionLoopback(Type type = Type::LoopbackTraffic, const IStrictComparison &comparison = CompareEq());
 
 	std::wstring toString() const override;
 	const GUID &identifier() const override;
@@ -18,6 +24,7 @@ public:
 
 private:
 
+	Type m_type;
 	ComparisonSpecification m_comparison;
 	common::Buffer m_assembled;
 };


### PR DESCRIPTION
Previously the loopback condition would match on interface type. This had the effect that it would not match loopback traffic on e.g. an ethernet adapter.

The condition has been extended so it can match on either interface type or traffic category, with the new default being the latter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/libwfp/18)
<!-- Reviewable:end -->
