### PR TITLE
Add missing virtual destructor

### DIFF
--- a/src/libwfp/conditions/ifiltercondition.h
+++ b/src/libwfp/conditions/ifiltercondition.h
@@ -11,6 +11,8 @@ struct IFilterCondition
 	virtual std::wstring toString() const = 0;
 	virtual const GUID &identifier() const = 0;
 	virtual const FWPM_FILTER_CONDITION0 &condition() const = 0;
+
+	virtual ~IFilterCondition() {}
 };
 
 }


### PR DESCRIPTION
This caused some filter condition types to leak memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/libwfp/29)
<!-- Reviewable:end -->
