### PR TITLE
Include missing header in providerbuilder.h

### DIFF
--- a/src/libwfp/providerbuilder.h
+++ b/src/libwfp/providerbuilder.h
@@ -6,6 +6,7 @@
 #include <fwpmu.h>
 #include <functional>
 #include <string>
+#include <memory>
 
 namespace wfp
 {


### PR DESCRIPTION
This fixes the intermittent errors seen here: https://github.com/mullvad/mullvadvpn-app/actions/runs/3637471315/jobs/6138521713.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/libwfp/34)
<!-- Reviewable:end -->
